### PR TITLE
Performance updates

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,202 @@
-“Software code created by U.S. Government employees is not subject to copyright
-in the United States (17 U.S.C. §105). The United States/Department of Commerce
-reserve all rights to seek and obtain copyright protection in countries other
-than the United States for Software authored in its entirety by the Department
-of Commerce. To this end, the Department of Commerce hereby grants to Recipient
-a royalty-free, nonexclusive license to use, copy, and create derivative works
-of the Software outside of the United States.”
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/doc/NextGen_ON_CONUS.md
+++ b/doc/NextGen_ON_CONUS.md
@@ -125,6 +125,18 @@ For code used to generate the initial config files for the various modules, the 
 
 The users are warned that since the simulated region is large, some of the initial config parameters values for some catchments may be unsuitable and cause the `ngen` execution to stop due to errors. Usually, in such cases, either `ngen` or the submodule itself may provide some hint as to the catchment ids or the location of the code that caused the error. Users may follow these hints to figure out as to which initial input parameter or parameters are initialized with inappropriate values. In the case of SFT, an initial value of `smcmax=1.0` would be too large. In the case of SMP, an initial value of `b=0.01` would be too small, for example.
 
+# Note on Parallel Computation with NetCDF Input data
+When running in parallel with NetCDF input data, you may encounter a disk IO bottleneck that gets worse with both the number of processes and the number of catchments.
+To remedy this, add the following `"enable_cache"` parameter to your realization.json. This parameter defaults to true if not included.
+```json
+    "forcing": {
+      "path": "./forcings/forcings.nc",
+      "provider": "NetCDF",
+      "enable_cache": false
+    }
+```   
+Depending on the partitions, speedups of ~1.5x-4x were observed with 157 catchments on a single machine with a sata ssda and 24 cores. The same tests on a 96 core machine yielded a ~5x-20x speedup
+
 # Build the Realization Configurations
 
 The realization configuration file, in JSON format, contains high level information to run a `ngen` simulation, such as interconnected submodules, paths to forcing file, shared libraries, initialization parameters, duration of simulation, I/O variables, etc. We have built the realization configurations for several commonly used submodules which are located in `data/baseline/`. These are built by adding one submodule at a time, performing a test run for a 10 day simulation. The successive submodules used are:

--- a/doc/REALIZATION_CONFIGURATION.md
+++ b/doc/REALIZATION_CONFIGURATION.md
@@ -33,6 +33,7 @@ The `global` key-value object must contain the following two object keys:
   * `params` must be a list that holds key-value pairs
 * `forcing`
   * key-value object with keys for `file_pattern` and `path` that define the default CSV file pattern and path for the input forcings relative to the executable directory. More recently, `ngen` developed the capability to handle forcing data in different formats. Thus, a `provider` value parameter can be used to explicitly define the format of the forcing data, such as NetCDF format, in the form "provider": "NetCDF".
+  * When using the NetCDF provider, the optional parameter `"enable_cache"` can be added to enable or disable ngen's internal forcing cache. This defaults to  `true` when omitted. Disabling the cache will generally reduce performance, except in parallel on systems experiencing disk I/O bottlenecks.
 
 ```
 "global": {

--- a/include/forcing/AorcForcing.hpp
+++ b/include/forcing/AorcForcing.hpp
@@ -40,11 +40,12 @@ struct forcing_params
   std::string provider;
   time_t simulation_start_t;
   time_t simulation_end_t;
+  bool enable_cache = true;
   /*
     Constructor for forcing_params
   */
-  forcing_params(std::string path, std::string provider, std::string start_time, std::string end_time):
-    path(path), provider(provider), start_time(start_time), end_time(end_time)
+  forcing_params(std::string path, std::string provider, std::string start_time, std::string end_time, bool enable_cache) :
+    path(path), provider(provider), start_time(start_time), end_time(end_time), enable_cache(enable_cache)
     {
       /// \todo converting to UTC can be tricky, especially if thread safety is a concern
       /* https://stackoverflow.com/questions/530519/stdmktime-and-timezone-info */

--- a/include/forcing/NetCDFPerFeatureDataProvider.hpp
+++ b/include/forcing/NetCDFPerFeatureDataProvider.hpp
@@ -53,14 +53,14 @@ namespace data_access
          * @param log_s An output log stream for messages from the underlying library. If a provider object for
          * the given path already exists, this argument will be ignored.
          */
-        static std::shared_ptr<NetCDFPerFeatureDataProvider> get_shared_provider(std::string input_path, time_t sim_start, time_t sim_end, utils::StreamHandler log_s);
+        static std::shared_ptr<NetCDFPerFeatureDataProvider> get_shared_provider(std::string input_path, time_t sim_start, time_t sim_end, utils::StreamHandler log_s, bool enable_cache);
 
         /**
          * @brief Cleanup the shared providers cache, ensuring that the files get closed.
          */
         static void cleanup_shared_providers();
 
-        NetCDFPerFeatureDataProvider(std::string input_path, time_t sim_start, time_t sim_end,  utils::StreamHandler log_s);
+        NetCDFPerFeatureDataProvider(std::string input_path, time_t sim_start, time_t sim_end,  utils::StreamHandler log_s, bool enable_cache);
 
         // Default implementation defined in the .cpp file so that
         // client code doesn't need to have the full definition of
@@ -135,6 +135,7 @@ namespace data_access
         std::map<std::string,netCDF::NcVar> ncvar_cache;
         std::map<std::string,std::string> units_cache;
         boost::compute::detail::lru_cache<std::string, std::shared_ptr<std::vector<double>>> value_cache;
+        bool enable_cache;
         size_t cache_slice_t_size = 1;
         size_t cache_slice_c_size = 1;
 

--- a/include/realizations/catchment/Formulation_Constructors.hpp
+++ b/include/realizations/catchment/Formulation_Constructors.hpp
@@ -49,7 +49,7 @@ namespace realization {
         }
 #if NGEN_WITH_NETCDF
         else if (forcing_config.provider == "NetCDF"){
-            fp = data_access::NetCDFPerFeatureDataProvider::get_shared_provider(forcing_config.path, forcing_config.simulation_start_t, forcing_config.simulation_end_t, output_stream);
+            fp = data_access::NetCDFPerFeatureDataProvider::get_shared_provider(forcing_config.path, forcing_config.simulation_start_t, forcing_config.simulation_end_t, output_stream, forcing_config.enable_cache);
         }
 #endif
         else if (forcing_config.provider == "NullForcingProvider"){

--- a/include/realizations/catchment/Formulation_Manager.hpp
+++ b/include/realizations/catchment/Formulation_Manager.hpp
@@ -517,54 +517,46 @@ namespace realization {
                     errMsg = "Received system error number " + std::to_string(errno);
                 }
 
-                // If the directory could be found and opened, we can go ahead and iterate
-                if (directory != nullptr) {
-                    bool match;
-                    while ((entry = readdir(directory))) {
-                        match = std::regex_match(entry->d_name, pattern);
-                        if( match ) {
-                            // If the entry is a regular file or symlink AND the name matches the pattern, 
-                            //    we can consider this ready to be interpretted as valid forcing data (even if it isn't)
-                            #ifdef _DIRENT_HAVE_D_TYPE
-                            if ( entry->d_type == DT_REG or entry->d_type == DT_LNK ) {
-                                return forcing_params(
-                                    path + entry->d_name,
-                                    provider,
-                                    simulation_time_config.start_time,
-                                    simulation_time_config.end_time,
-                                    enable_cache
-                                );
-                            }
-                            else if ( entry->d_type == DT_UNKNOWN )
-                            #endif
-                            {
-                                //dirent is not guaranteed to provide propoer file type identification in d_type
-                                //so if a system returns unknown or it isn't supported, need to use stat to determine if it is a file
-                                struct stat st;
-                                if( stat((path+entry->d_name).c_str(), &st) != 0) {
-                                    throw std::runtime_error("Could not stat file "+path+entry->d_name);
-                                }
-                                if( S_ISREG(st.st_mode) ) {
-                                    //Sinde we used stat and not lstat, we get the result of the target of links as well
-                                    //so this covers both cases we are interested in.
-                                    return forcing_params(
-                                        path + entry->d_name,
-                                        provider,
-                                        simulation_time_config.start_time,
-                                        simulation_time_config.end_time,
-                                        enable_cache
-                                    );
-                                }
-                                throw std::runtime_error("Forcing data is path "+path+entry->d_name+" is not a file");
-                            }
-                        } //no match found, try next entry
-                    } // end while iter dir
-                } //end if directory
-                else {
-                    // The directory wasn't found or otherwise couldn't be opened; forcing data cannot be retrieved
+                // If the directory could not be opened, throw an error
+                if (directory == nullptr) {
+                    errMsg = "Received system error number " + std::to_string(errno);
                     throw std::runtime_error("Error opening forcing data dir '" + path + "' after " + std::to_string(attemptCount) + " attempts: " + errMsg);
                 }
 
+                // Check if the file pattern is a file itself
+                std::ifstream possible_file(path + filepattern);
+                if (possible_file.good()) {
+                    possible_file.close();
+                    closedir(directory);
+                    return forcing_params(
+                        path + filepattern,
+                        provider,
+                        simulation_time_config.start_time,
+                        simulation_time_config.end_time,
+                        enable_cache
+                    );
+                }
+
+                // If that failed, use regex to find the file
+                bool match;
+                while ((entry = readdir(directory))) {
+                    match = std::regex_match(entry->d_name, pattern);
+                    if( match ) {
+                        possible_file.open(path + entry->d_name);
+                        if (possible_file.good()) {
+                            possible_file.close();
+                            closedir(directory);
+                            return forcing_params(
+                                path + entry->d_name,
+                                provider,
+                                simulation_time_config.start_time,
+                                simulation_time_config.end_time,
+                                enable_cache
+                            );
+                        }
+                    }
+                }
+                possible_file.close();
                 closedir(directory);
 
                 throw std::runtime_error("Forcing data could not be found for '" + identifier + "'");

--- a/include/realizations/catchment/Formulation_Manager.hpp
+++ b/include/realizations/catchment/Formulation_Manager.hpp
@@ -318,6 +318,33 @@ namespace realization {
  
                 //for case where there is no output_root in the realization file
                 return "./";
+
+            }
+
+             /**
+             * @brief Check if the formulation has catchment output writing enabled
+             *
+             * @code{.cpp}
+             * // Example config:
+             * // ...
+             * // "write_catchment_output": false
+             * // ...
+             * const auto manager = Formulation_Manger(CONFIG);
+             * manager.is_catchment_writing_enabled();
+             * //> false
+             * @endcode
+             * 
+             * @return bool
+             */
+            bool is_catchment_writing_enabled() const {
+                const auto write_enabled = this->tree.get_optional<std::string>("write_catchment_output");
+                if (write_enabled != boost::none && *write_enabled != "") {
+                    // if any variation of "false" or "no" or 0 is found, return false
+                    if (write_enabled->compare("false") == 0 || write_enabled->compare("no") == 0 || write_enabled->compare("0") == 0) {
+                        return false;
+                    }
+                } 
+                return true;
             }
 
             /**

--- a/include/realizations/catchment/Formulation_Manager.hpp
+++ b/include/realizations/catchment/Formulation_Manager.hpp
@@ -422,6 +422,12 @@ namespace realization {
             }
 
             forcing_params get_forcing_params(const geojson::PropertyMap &forcing_prop_map, std::string identifier, simulation_time_params &simulation_time_config) {
+                bool enable_cache = true;
+
+                if (forcing_prop_map.count("enable_cache") != 0) {
+                    enable_cache = forcing_prop_map.at("enable_cache").as_boolean();
+                }
+
                 std::string path = "";
                 if(forcing_prop_map.count("path") != 0){
                     path = forcing_prop_map.at("path").as_string();
@@ -435,7 +441,8 @@ namespace realization {
                         path,
                         provider,
                         simulation_time_config.start_time,
-                        simulation_time_config.end_time
+                        simulation_time_config.end_time,
+                        enable_cache
                     );
                 }
 
@@ -524,7 +531,8 @@ namespace realization {
                                     path + entry->d_name,
                                     provider,
                                     simulation_time_config.start_time,
-                                    simulation_time_config.end_time
+                                    simulation_time_config.end_time,
+                                    enable_cache
                                 );
                             }
                             else if ( entry->d_type == DT_UNKNOWN )
@@ -543,7 +551,8 @@ namespace realization {
                                         path + entry->d_name,
                                         provider,
                                         simulation_time_config.start_time,
-                                        simulation_time_config.end_time
+                                        simulation_time_config.end_time,
+                                        enable_cache
                                     );
                                 }
                                 throw std::runtime_error("Forcing data is path "+path+entry->d_name+" is not a file");

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -558,24 +558,30 @@ int main(int argc, char *argv[]) {
     } //done time
 
 #if NGEN_WITH_MPI
-    MPI_Barrier(MPI_COMM_WORLD);
-#endif
+    // Ibarrier used to reduce the poll rate and cpu usage boosting performance on variable clock speed systems
+    MPI_Request barrier_request;
+    MPI_Ibarrier(MPI_COMM_WORLD, &barrier_request);
 
-    if (mpi_rank == 0)
-    {
-        std::cout << "Finished " << manager->Simulation_Time_Object->get_total_output_times() << " timesteps." << std::endl;
+    int flag = 0;
+    const int sleep_microseconds = 100000;  // 100 millisecond sleep
+
+    // Wait for all ranks to reach the barrier
+    while (!flag) {
+        MPI_Test(&barrier_request, &flag, MPI_STATUS_IGNORE);
+        if (!flag) {
+            usleep(sleep_microseconds);
+        }
     }
-
-    auto time_done_simulation = std::chrono::steady_clock::now();
-    std::chrono::duration<double> time_elapsed_simulation = time_done_simulation - time_done_init;
-
-#if NGEN_WITH_MPI
-    MPI_Barrier(MPI_COMM_WORLD);
 #endif
+    if (mpi_rank == 0) {    
+        std::cout << "Finished " << manager->Simulation_Time_Object->get_total_output_times() << " timesteps." << std::endl;
+
+        auto time_done_simulation = std::chrono::steady_clock::now();
+        std::chrono::duration<double> time_elapsed_simulation = time_done_simulation - time_done_init;
+
+
 
 #if NGEN_WITH_ROUTING
-    if (mpi_rank == 0)
-    { // Run t-route from single process
         if(manager->get_using_routing()) {
           //Note: Currently, delta_time is set in the t-route yaml configuration file, and the
           //number_of_timesteps is determined from the total number of nexus outputs in t-route.
@@ -587,14 +593,11 @@ int main(int argc, char *argv[]) {
           
           router->route(number_of_timesteps, delta_time); 
         }
-    }
 #endif
 
     auto time_done_routing = std::chrono::steady_clock::now();
     std::chrono::duration<double> time_elapsed_routing = time_done_routing - time_done_simulation;
 
-    if (mpi_rank == 0)
-    {
         std::cout << "NGen top-level timings:"
                   << "\n\tNGen::init: " << time_elapsed_init.count()
                   << "\n\tNGen::simulation: " << time_elapsed_simulation.count()
@@ -602,10 +605,28 @@ int main(int argc, char *argv[]) {
                   << "\n\tNGen::routing: " << time_elapsed_routing.count()
 #endif
                   << std::endl;
+#if NGEN_WITH_MPI
+        for (int i = 1; i < mpi_num_procs; ++i) {
+            MPI_Send(NULL, 0, MPI_INT, i, 0, MPI_COMM_WORLD);
+        }
+    }
+    else {
+        // Non-root processes
+        MPI_Request recv_request;
+        MPI_Irecv(NULL, 0, MPI_INT, 0, 0, MPI_COMM_WORLD, &recv_request);
+        
+        // manually waiting for troute to finish here to free up the cpu for troute to use it's own parallelism
+        int recv_flag = 0;
+        while (!recv_flag) {
+            MPI_Test(&recv_request, &recv_flag, MPI_STATUS_IGNORE);
+            if (!recv_flag) {
+                usleep(sleep_microseconds);
+            }
+        }
+#endif
     }
 
   manager->finalize();
-
 #if NGEN_WITH_MPI
     MPI_Finalize();
 #endif

--- a/src/core/HY_Features.cpp
+++ b/src/core/HY_Features.cpp
@@ -32,7 +32,14 @@ HY_Features::HY_Features(network::Network network, std::shared_ptr<Formulation_M
         {
           //Find and prepare formulation
           auto formulation = formulations->get_formulation(feat_id);
-          formulation->set_output_stream(formulations->get_output_root() + feat_id + ".csv");
+          if (formulations->is_catchment_writing_enabled() == true)
+          {
+            formulation->set_output_stream(formulations->get_output_root() + feat_id + ".csv");
+          }
+          else
+          {
+            formulation->set_output_stream("/dev/null");
+          }
           // TODO: add command line or config option to have this be omitted
           //FIXME why isn't default param working here??? get_output_header_line() fails.
           formulation->write_output("Time Step,""Time,"+formulation->get_output_header_line(",")+"\n");

--- a/src/core/HY_Features_MPI.cpp
+++ b/src/core/HY_Features_MPI.cpp
@@ -38,7 +38,14 @@ HY_Features_MPI::HY_Features_MPI( PartitionData partition_data, geojson::GeoJSON
         {
           //Find and prepare formulation
           auto formulation = formulations->get_formulation(feat_id);
-          formulation->set_output_stream(formulations->get_output_root() + feat_id + ".csv");
+          if (formulations->is_catchment_writing_enabled() == true)
+          {
+            formulation->set_output_stream(formulations->get_output_root() + feat_id + ".csv");
+          }
+          else
+          {
+            formulation->set_output_stream("/dev/null");
+          };
           // TODO: add command line or config option to have this be omitted
           //FIXME why isn't default param working here??? get_output_header_line() fails.
           formulation->write_output("Time Step,""Time,"+formulation->get_output_header_line(",")+"\n");

--- a/src/forcing/NetCDFPerFeatureDataProvider.cpp
+++ b/src/forcing/NetCDFPerFeatureDataProvider.cpp
@@ -10,14 +10,14 @@ std::map<std::string, std::shared_ptr<data_access::NetCDFPerFeatureDataProvider>
 
 namespace data_access {
 
-std::shared_ptr<NetCDFPerFeatureDataProvider> NetCDFPerFeatureDataProvider::get_shared_provider(std::string input_path, time_t sim_start, time_t sim_end, utils::StreamHandler log_s)
+std::shared_ptr<NetCDFPerFeatureDataProvider> NetCDFPerFeatureDataProvider::get_shared_provider(std::string input_path, time_t sim_start, time_t sim_end, utils::StreamHandler log_s, bool enable_cache)
 {
     const std::lock_guard<std::mutex> lock(shared_providers_mutex);
     std::shared_ptr<NetCDFPerFeatureDataProvider> p;
     if(shared_providers.count(input_path) > 0){
         p = shared_providers[input_path];
     } else {
-        p = std::make_shared<data_access::NetCDFPerFeatureDataProvider>(input_path, sim_start, sim_end, log_s);
+        p = std::make_shared<data_access::NetCDFPerFeatureDataProvider>(input_path, sim_start, sim_end, log_s, enable_cache);
         shared_providers[input_path] = p;
     }
     return p;
@@ -30,9 +30,10 @@ void NetCDFPerFeatureDataProvider::cleanup_shared_providers()
     shared_providers.clear();
 }
 
-NetCDFPerFeatureDataProvider::NetCDFPerFeatureDataProvider(std::string input_path, time_t sim_start, time_t sim_end,  utils::StreamHandler log_s) : log_stream(log_s), value_cache(20),
+NetCDFPerFeatureDataProvider::NetCDFPerFeatureDataProvider(std::string input_path, time_t sim_start, time_t sim_end,  utils::StreamHandler log_s, bool enable_cache) : log_stream(log_s), value_cache(20),
     sim_start_date_time_epoch(sim_start),
-    sim_end_date_time_epoch(sim_end)
+    sim_end_date_time_epoch(sim_end),
+    enable_cache(enable_cache)
 {
     //size_t sizep = 1073741824, nelemsp = 202481;
     //float preemptionp = 0.75;
@@ -322,105 +323,114 @@ size_t NetCDFPerFeatureDataProvider::get_ts_index_for_time(const time_t &epoch_t
 double NetCDFPerFeatureDataProvider::get_value(const CatchmentAggrDataSelector& selector, ReSampleMethod m) 
 {
     auto init_time = selector.get_init_time();
-    auto stop_time = init_time + selector.get_duration_secs(); // scope hiding! BAD JUJU!
-    
     size_t idx1 = get_ts_index_for_time(init_time);
-    size_t idx2;
-    try {
-        idx2 = get_ts_index_for_time(stop_time-1); // Don't include next timestep when duration % timestep = 0
-    }
-    catch(const std::out_of_range &e){
-        idx2 = get_ts_index_for_time(this->stop_time-1); //to the edge
-    }
-
-    auto stride = idx2 - idx1;
-
-    std::vector<std::size_t> start, count;
-
     auto cat_pos = id_pos[selector.get_id()];
-
-
-
-    double t1 = time_vals[idx1];
-    double t2 = time_vals[idx2];
-
+    std::vector<std::size_t> start, count;
     double rvalue = 0.0;
-    
+    std::string native_units = get_ncvar_units(selector.get_variable_name());
     auto ncvar = get_ncvar(selector.get_variable_name());
 
-    std::string native_units = get_ncvar_units(selector.get_variable_name());
-
-    auto read_len = idx2 - idx1 + 1;
-
-    std::vector<double> raw_values;
-    raw_values.resize(read_len);
-
-    //TODO: Currently assuming a whole variable cache slice across all catchments for a single timestep...but some stuff here to support otherwise.
-    size_t cache_slices_t_n = read_len / cache_slice_t_size; // Integer division!
-    // For reference: https://stackoverflow.com/a/72030286
-    for( size_t i = 0; i < cache_slices_t_n; i++ ) {
-        std::shared_ptr<std::vector<double>> cached;
-        int cache_t_idx = (idx1 - (idx1 % cache_slice_t_size) + i);
-        std::string key = ncvar.getName() + "|" + std::to_string(cache_t_idx);
-        if(value_cache.contains(key)){
-            cached = value_cache.get(key).get();
-        } else {
-            cached = std::make_shared<std::vector<double>>(cache_slice_c_size * cache_slice_t_size);
-            start.clear();
-            start.push_back(0); // only always 0 when cache_slice_c_size = numids!
-            start.push_back(cache_t_idx * cache_slice_t_size);
-            count.clear();
-            count.push_back(cache_slice_c_size);
-            count.push_back(cache_slice_t_size); // Must be 1 for now!...probably...
-            ncvar.getVar(start,count,&(*cached)[0]);
-            value_cache.insert(key, cached);
-        }
-        for( size_t j = 0; j < cache_slice_t_size; j++){
-            raw_values[i+j] = cached->at((j*cache_slice_t_size) + cat_pos);
-        }
-    }
-
-    
-    rvalue = 0.0;
-
-    double a , b = 0.0;
-    
-    a = 1.0 - ( (t1 - init_time) / time_stride );
-    rvalue += (a * raw_values[0]);
-
-    for( size_t i = 1; i < raw_values.size() -1; ++i )
+    if (enable_cache == false)
     {
-        rvalue += raw_values[i];
+        // This cacheless version is slower serially than the cache version, but faster in parallel
+        // The cache is not shared between processes which can cause a lot of redundant reads and an IO bottleneck
+        // vector start is the catchment index and the time index
+        // vector count is how much to read in both directions
+        start.clear();
+        start.push_back(cat_pos);
+        start.push_back(idx1);
+        count.clear();
+        count.push_back(1);
+        count.push_back(1); 
+        ncvar.getVar(start, count, &rvalue);
     }
-
-    if (  raw_values.size() > 1) // likewise the last data value may not be fully in the window
+    else
     {
-        b = (stop_time - t2) / time_stride;
-        rvalue += (b * raw_values.back() );
-    }
-
-    // account for the resampling methods
-    switch(m)
-    {
-        case SUM:   // we allready have the sum so do nothing
-            ;
-        break;
-
-        case MEAN: 
-        { 
-            // This is getting a length weighted mean
-            // the data values where allready scaled for where there was only partial use of a data value
-            // so we just need to do a final scale to account for the differnce between time_stride and duration_s
-
-            double scale_factor = (selector.get_duration_secs() > time_stride ) ? (time_stride / selector.get_duration_secs()) : (1.0 / (a + b));
-            rvalue *= scale_factor;
+        auto stop_time = init_time + selector.get_duration_secs(); // scope hiding! BAD JUJU!
+        
+        size_t idx2;
+        try {
+            idx2 = get_ts_index_for_time(stop_time-1); // Don't include next timestep when duration % timestep = 0
         }
-        break;
+        catch(const std::out_of_range &e){
+            idx2 = get_ts_index_for_time(this->stop_time-1); //to the edge
+        }
 
-        default:
-            ;
+        auto stride = idx2 - idx1;
+
+        double t1 = time_vals[idx1];
+        double t2 = time_vals[idx2];
+
+        auto read_len = idx2 - idx1 + 1;
+
+        std::vector<double> raw_values;
+        raw_values.resize(read_len);
+
+
+
+        //TODO: Currently assuming a whole variable cache slice across all catchments for a single timestep...but some stuff here to support otherwise.
+        size_t cache_slices_t_n = read_len / cache_slice_t_size; // Integer division!
+        // For reference: https://stackoverflow.com/a/72030286
+        for( size_t i = 0; i < cache_slices_t_n; i++ ) {
+            std::shared_ptr<std::vector<double>> cached;
+            int cache_t_idx = (idx1 - (idx1 % cache_slice_t_size) + i);
+            std::string key = ncvar.getName() + "|" + std::to_string(cache_t_idx);
+            if(value_cache.contains(key)){
+                cached = value_cache.get(key).get();
+            } else {
+                cached = std::make_shared<std::vector<double>>(cache_slice_c_size * cache_slice_t_size);
+                start.clear();
+                start.push_back(0); // only always 0 when cache_slice_c_size = numids!
+                start.push_back(cache_t_idx * cache_slice_t_size);
+                count.clear();
+                count.push_back(cache_slice_c_size);
+                count.push_back(cache_slice_t_size); // Must be 1 for now!...probably...
+                ncvar.getVar(start,count,&(*cached)[0]);
+                value_cache.insert(key, cached);
+            }
+            for( size_t j = 0; j < cache_slice_t_size; j++){
+                raw_values[i+j] = cached->at((j*cache_slice_t_size) + cat_pos);
+            }
+        }    
+        rvalue = 0.0;
+
+        double a , b = 0.0;
+        
+        a = 1.0 - ( (t1 - init_time) / time_stride );
+        rvalue += (a * raw_values[0]);
+
+        for( size_t i = 1; i < raw_values.size() -1; ++i )
+        {
+            rvalue += raw_values[i];
+        }
+
+        if (  raw_values.size() > 1) // likewise the last data value may not be fully in the window
+        {
+            b = (stop_time - t2) / time_stride;
+            rvalue += (b * raw_values.back() );
+        }
+        // account for the resampling methods
+        switch(m)
+        {
+            case SUM:   // we allready have the sum so do nothing
+                ;
+            break;
+
+            case MEAN: 
+            { 
+                // This is getting a length weighted mean
+                // the data values where allready scaled for where there was only partial use of a data value
+                // so we just need to do a final scale to account for the differnce between time_stride and duration_s
+
+                double scale_factor = (selector.get_duration_secs() > time_stride ) ? (time_stride / selector.get_duration_secs()) : (1.0 / (a + b));
+                rvalue *= scale_factor;
+            }
+            break;
+
+            default:
+                ;
+        }
     }
-
     try 
     {
         return UnitsHelper::get_converted_value(native_units, rvalue, selector.get_output_units());
@@ -433,7 +443,6 @@ double NetCDFPerFeatureDataProvider::get_value(const CatchmentAggrDataSelector& 
         return rvalue;
     }
 
-    return rvalue;
 }
 
 std::vector<double> NetCDFPerFeatureDataProvider::get_values(const CatchmentAggrDataSelector& selector, data_access::ReSampleMethod m)

--- a/utilities/partitioning/local_only_partitions.py
+++ b/utilities/partitioning/local_only_partitions.py
@@ -1,0 +1,118 @@
+import argparse
+from math import ceil
+from pathlib import Path
+import sqlite3
+import json
+import multiprocessing
+from collections import defaultdict
+from typing import List, Tuple
+
+def get_cat_to_nex_flowpairs(hydrofabric: Path) -> List[Tuple]:
+    sql_query = "SELECT divide_id, toid FROM divides"
+    try:
+        con = sqlite3.connect(str(hydrofabric.absolute()))
+        edges = con.execute(sql_query).fetchall()
+        con.close()
+    except sqlite3.Error as e:
+        print(f"SQLite error: {e}")
+        raise
+    unique_edges = list(set(edges))
+    return unique_edges
+
+def create_partitions(geopackage_path: Path, num_partitions: int = None, output_folder: Path = None) -> int:
+    """
+    The partitioning algorithm is as follows:
+    1. Get the list of catchments and their corresponding nexus
+    2. Sort the nexus by the number of catchments
+    3. Create a list of partitions and calculate the maximum number of catchments each partition should have
+    4. Loop through the sorted nexus and add them to the partitions
+    5. If the number of catchments in a partition exceeds the maximum, move to the next partition
+    6. If we've looped through all partitions and not added a nexus, then the partitioning has failed
+    7. Write the partitions to a JSON file
+    8. Return the number of partitions
+
+    This partitioning scheme does not take into account connectivity of the larger network and will 
+    likely perform extremely poorly if used with routing that runs as the simulation progresses,
+    rather than all at once at once after the main model simulations have completed.
+
+    If routing is not tightly coupled, this partitioning scheme eliminates almost all mpi communication.
+
+    """
+
+    if output_folder is None:
+        output_folder = Path.cwd()
+    else:
+        output_folder = Path(output_folder)
+
+    if num_partitions is None:
+        num_partitions = multiprocessing.cpu_count()
+
+    cat_to_nex_pairs = get_cat_to_nex_flowpairs(geopackage_path)
+    num_cats = len(cat_to_nex_pairs)
+    nexus = defaultdict(list)
+
+    for cat, nex in cat_to_nex_pairs:
+        nexus[nex].append(cat)
+
+    num_partitions = min(num_partitions, len(nexus.keys()))
+
+    partitions = []
+    for i in range(num_partitions):
+        part = {}
+        part["id"] = i
+        part["cat-ids"] = []
+        part["nex-ids"] = []
+        part["remote-connections"] = []
+        partitions.append(part)
+
+    # sort the nexus by number of cats
+    sorted_nexus = sorted(nexus.items(), key=lambda x: len(x[1]), reverse=True)
+
+    # figure out roughly how many cats to put in each partition
+    max_cats = ceil(num_cats / num_partitions)
+
+    nex, cats = sorted_nexus.pop(0)
+
+    # the maximum number of catchments in a partition is max_cats, but some nexuses may have more than max_cats catchments
+    max_cats = max(len(cats), max_cats)
+    i = 0
+    j = num_partitions
+    print(f"Number of partitions: {num_partitions}")
+    print(f"Number of catchments: {num_cats}")
+    print(f"Number of nexus: {len(nexus.keys())}")
+    print(f"Max cats per partition: {max_cats}")
+    while True:
+        if len(partitions[i]["cat-ids"]) + len(cats) <= max_cats:
+            partitions[i]["cat-ids"].extend(cats)
+            partitions[i]["nex-ids"].append(nex)
+            if len(sorted_nexus) == 0:
+                break
+            nex, cats = sorted_nexus.pop(0)
+            # If we've looped through all partitions and not added a nexus, then the partitioning has failed
+            # I don't think this should ever happen, worth checking for though
+            j = num_partitions
+        i = (i + 1) % num_partitions
+        j -= 1
+        if j == 0:
+            raise Exception("Unable to balance partitions")
+
+    with open(output_folder / f"partitions_{num_partitions}.json", "w") as f:
+        f.write(json.dumps({"partitions": partitions}, indent=4))
+    
+    return num_partitions
+
+def main():
+    parser = argparse.ArgumentParser(description="Create partitions for hydrofabric.")
+    parser.add_argument("path", type=str, help="The file path to the hydrofabric.")
+    parser.add_argument("num_partitions", type=int,help="The desired number of partitions.")
+    parser.add_argument("output_folder", type=str, help="The path of the folder output in.")
+    args = parser.parse_args()
+
+    paths = Path(args.path)
+
+    actual_num_partitions = create_partitions(paths, args.num_partitions, args.output_folder)
+    print(f"Actual number of partitions: \n{actual_num_partitions}")
+
+if __name__ == "__main__":
+    main()
+    


### PR DESCRIPTION
Tidies up and adds several performance enhancements:
full details of original testing: [ngen init speedup](https://github.com/NOAA-OWP/ngen/pull/843)  [troute speedup](https://github.com/NOAA-OWP/ngen/pull/846) [parallel processing speedup](https://github.com/NOAA-OWP/ngen/pull/894)

- Adds new optional realization parameter `write_catchment_outputs` which allows you to disable the individual catchment csv files, useful for calibration and reducing the number of files produced running over large areas
- Replaced the mpi barriers with manual wait loops that poll every 100ms to reduce cpu useage, allowing troute to use the full cpu
- Adds an option to disable netcdf forcing cache,  speedup for running in parallel
- Adds script to create partitions with no remotes (no mpi communication), speedup for running in parallel
- Refactors the forcing file finding to speed up the ngen init portion of the ngen run

Tested in ngiab with additional script added for the alternative partitioning, url [here](https://github.com/CIROH-UA/NGIAB-CloudInfra/tree/performance_updates).