### PR TITLE
fix local_only_partitions.py

### DIFF
--- a/utilities/partitioning/local_only_partitions.py
+++ b/utilities/partitioning/local_only_partitions.py
@@ -76,7 +76,7 @@ def create_partitions(geopackage_path: Path, num_partitions: int = None, output_
     # the maximum number of catchments in a partition is max_cats, but some nexuses may have more than max_cats catchments
     max_cats = max(len(cats), max_cats)
     i = 0
-    j = num_partitions
+    j = num_partitions + 1
     print(f"Number of partitions: {num_partitions}")
     print(f"Number of catchments: {num_cats}")
     print(f"Number of nexus: {len(nexus.keys())}")
@@ -90,7 +90,8 @@ def create_partitions(geopackage_path: Path, num_partitions: int = None, output_
             nex, cats = sorted_nexus.pop(0)
             # If we've looped through all partitions and not added a nexus, then the partitioning has failed
             # I don't think this should ever happen, worth checking for though
-            j = num_partitions
+            # +1 added to make sure the values are attempted to be added to ALL partitions
+            j = num_partitions + 1
         i = (i + 1) % num_partitions
         j -= 1
         if j == 0:


### PR DESCRIPTION
fix partitioning edge case with 2 partitions

```bash
[jcunningham8@compute001 NGIAB-HPCInfra]$ python test.py ../AWI_16_2863657_007/config/cat-2863657_subset.gpkg 1 .
Number of partitions: 1
Number of catchments: 241
Number of nexus: 122
Max cats per partition: 241
Actual number of partitions:
1
[jcunningham8@compute001 NGIAB-HPCInfra]$ python test.py ../AWI_16_2863657_007/config/cat-2863657_subset.gpkg 10 .
Number of partitions: 10
Number of catchments: 241
Number of nexus: 122
Max cats per partition: 25
Actual number of partitions:
10
[jcunningham8@compute001 NGIAB-HPCInfra]$ python test.py ../AWI_16_2863657_007/config/cat-2863657_subset.gpkg 100 .
Number of partitions: 100
Number of catchments: 241
Number of nexus: 122
Max cats per partition: 5
Actual number of partitions:
100
[jcunningham8@compute001 NGIAB-HPCInfra]$ python test.py ../AWI_16_2863657_007/config/cat-2863657_subset.gpkg 1000 .
Number of partitions: 122
Number of catchments: 241
Number of nexus: 122
Max cats per partition: 5
Actual number of partitions:
122
[jcunningham8@compute001 NGIAB-HPCInfra]$ python test.py ../AWI_16_2863657_007/config/cat-2863657_subset.gpkg 2 .
Number of partitions: 2
Number of catchments: 241
Number of nexus: 122
Max cats per partition: 121
Actual number of partitions:
2
```

fixes issues in https://github.com/CIROH-UA/NGIAB-HPCInfra/pull/39