### PR TITLE
fix: reduce formulation manager memory consumption with catchment con…

### DIFF
--- a/include/realizations/catchment/Formulation_Manager.hpp
+++ b/include/realizations/catchment/Formulation_Manager.hpp
@@ -172,6 +172,10 @@ namespace realization {
                        // } //end for formulaitons
                       }//end for catchments
 
+                    // Remove the catchment config section from memory
+                    // It may be useful to remove each subtree after it is processed above
+                    // and/or remove the entire tree after it is read to avoid excessive memory usage
+                    (*possible_catchment_configs).clear();
 
                 }//end if possible_catchment_configs
 


### PR DESCRIPTION
There are likely some other mechanics that could be useful to consider here, but would require some additional refactoring of the manager class.  For now, this PR simply drops the potentially largest (and most dynamic) in-memory component read from a realization once the information is no longer needed in ptree form.  This should reduce initialization overhead when catchments are configured explicitly in the realization.