### PR TITLE
added hawaii albers as accepted crs

### DIFF
--- a/include/geopackage/proj.hpp
+++ b/include/geopackage/proj.hpp
@@ -16,7 +16,8 @@ struct epsg
     enum {
         wgs84        = 4326,
         conus_albers = 5070,
-        mercator     = 3857
+        mercator     = 3857,
+        hawaii_albers = 102007 // it's an ESRI code but might as well treat it like EPSG...
     };
 
     static srs_type get(uint32_t srid);

--- a/src/geopackage/proj.cpp
+++ b/src/geopackage/proj.cpp
@@ -6,7 +6,9 @@ namespace srs {
 const epsg::def_type epsg::defs_ = {
     {4326, epsg::srs_type(bg::srs::dpar::proj_longlat)(bg::srs::dpar::ellps_wgs84)(bg::srs::dpar::datum_wgs84)(bg::srs::dpar::no_defs)},
     {5070, epsg::srs_type(bg::srs::dpar::proj_aea)(bg::srs::dpar::ellps_grs80)(bg::srs::dpar::towgs84, {0,0,0,0,0,0,0})(bg::srs::dpar::lat_0, 23)(bg::srs::dpar::lon_0, -96)(bg::srs::dpar::lat_1, 29.5)(bg::srs::dpar::lat_2, 45.5)(bg::srs::dpar::x_0, 0)(bg::srs::dpar::y_0, 0)},
-    {3857, epsg::srs_type(bg::srs::dpar::proj_merc)(bg::srs::dpar::units_m)(bg::srs::dpar::no_defs)(bg::srs::dpar::a, 6378137)(bg::srs::dpar::b, 6378137)(bg::srs::dpar::lat_ts, 0)(bg::srs::dpar::lon_0, 0)(bg::srs::dpar::x_0, 0)(bg::srs::dpar::y_0, 0)(bg::srs::dpar::k, 1)}
+    {3857, epsg::srs_type(bg::srs::dpar::proj_merc)(bg::srs::dpar::units_m)(bg::srs::dpar::no_defs)(bg::srs::dpar::a, 6378137)(bg::srs::dpar::b, 6378137)(bg::srs::dpar::lat_ts, 0)(bg::srs::dpar::lon_0, 0)(bg::srs::dpar::x_0, 0)(bg::srs::dpar::y_0, 0)(bg::srs::dpar::k, 1)},
+    {102007, epsg::srs_type(bg::srs::dpar::proj_aea)(bg::srs::dpar::lat_1,8)(bg::srs::dpar::lat_2,18)(bg::srs::dpar::lat_0,13)(bg::srs::dpar::lon_0,-157)(bg::srs::dpar::x_0,0)(bg::srs::dpar::y_0,0)(bg::srs::dpar::ellps_grs80)(bg::srs::dpar::datum_nad83)(bg::srs::dpar::units_m)(bg::srs::dpar::no_defs)}
+    // 102007 not an EPSG reference system (it's ESRI) but might as well treat it like an EPSG reference system
 };
 
 auto epsg::get(uint32_t srid) -> srs_type


### PR DESCRIPTION
Added ESRI 102007 (Hawaii Albers) as accepted CRS, so that preprocessed Hawaii forcing data no longer needs to be transformed to EPSG 5070 (CONUS Albers) in order to be inputs for a nextgen run