### PR TITLE
Correctly incorporate SMP/SFT into build process

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -27,11 +27,11 @@
 [submodule "extern/evapotranspiration/evapotranspiration"]
 	path = extern/evapotranspiration/evapotranspiration
 	url = https://github.com/NOAA-OWP/evapotranspiration.git
-        branch = master
+    branch = master
 [submodule "extern/SoilFreezeThaw/SoilFreezeThaw"]
 	path = extern/SoilFreezeThaw/SoilFreezeThaw
 	url = https://github.com/NOAA-OWP/SoilFreezeThaw
-        branch = master
+    branch = master
 [submodule "extern/SoilMoistureProfiles/SoilMoistureProfiles"]
 	path = extern/SoilMoistureProfiles/SoilMoistureProfiles
 	url = https://github.com/NOAA-OWP/SoilMoistureProfiles

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,15 +73,20 @@ deprecated_option(OLD QUIET                 NEW NGEN_QUIET)
 
 # Options to automate building of extern-distributed models
 option(NGEN_WITH_EXTERN_SLOTH                            "Build with extern-distributed SLoTH"            ON)
+option(NGEN_WITH_EXTERN_SMP                              "Build with extern-distributed SMP"              OFF)
+option(NGEN_WITH_EXTERN_SFT                              "Build with extern-distributed SFT"              OFF)
 cmake_dependent_option(NGEN_WITH_EXTERN_TOPMODEL         "Build with extern-distributed TOPMODEL"         ON "NGEN_WITH_BMI_C"       OFF)
 cmake_dependent_option(NGEN_WITH_EXTERN_CFE              "Build with extern-distributed CFE"              ON "NGEN_WITH_BMI_C"       OFF)
 cmake_dependent_option(NGEN_WITH_EXTERN_PET              "Build with extern-distributed PET"              ON "NGEN_WITH_BMI_C"       OFF)
 cmake_dependent_option(NGEN_WITH_EXTERN_NOAH_OWP_MODULAR "Build with extern-distributed Noah-OWP-Modular" ON "NGEN_WITH_BMI_FORTRAN" OFF)
+cmake_dependent_option(NGEN_WITH_EXTERN_PET              "Build with extern-distributed PET"              ON "NGEN_WITH_BMI_C"       OFF)
 
 # Allow enabling of all extern models dependent on NGen options given.
 option(NGEN_WITH_EXTERN_ALL OFF)
 if(NGEN_WITH_EXTERN_ALL)
     set(NGEN_WITH_EXTERN_SLOTH ON)
+    set(NGEN_WITH_EXTERN_SMP   ON)
+    set(NGEN_WITH_EXTERN_SFT   ON)
 
     # Ensure C support is enabled
     if(NGEN_WITH_BMI_C)
@@ -211,6 +216,32 @@ if(NGEN_WITH_EXTERN_SLOTH)
     set_target_properties(slothmodel PROPERTIES CXX_VISIBILITY_PRESET default)
 endif()
 
+if (NGEN_WITH_EXTERN_SMP OR NGEN_WITH_EXTERN_SFT)
+    # SoilMoistureProfiles and SoilFreezeThaw expect this setting,
+    # as they have alternative standalone build modes.
+    set(NGEN ON CACHE BOOL "Type setting for SMP and SFT")
+endif()
+
+if(NGEN_WITH_EXTERN_SMP)
+    # SoilMoistureProfiles
+    add_external_subdirectory(
+        SOURCE     "${NGEN_EXT_DIR}/SoilMoistureProfiles/SoilMoistureProfiles"
+        OUTPUT     "${NGEN_EXT_DIR}/SoilMoistureProfiles/cmake_build"
+        GIT_UPDATE "${NGEN_EXT_DIR}/SoilMoistureProfiles/SoilMoistureProfiles"
+        IMPORTS    smpbmi
+    )
+endif()
+
+if(NGEN_WITH_EXTERN_SFT)
+    # SoilFreezeThaw
+    add_external_subdirectory(
+        SOURCE     "${NGEN_EXT_DIR}/SoilFreezeThaw/SoilFreezeThaw"
+        OUTPUT     "${NGEN_EXT_DIR}/SoilFreezeThaw/cmake_build"
+        GIT_UPDATE "${NGEN_EXT_DIR}/SoilFreezeThaw/SoilFreezeThaw"
+        IMPORTS    sftbmi
+    )
+endif()
+
 # -----------------------------------------------------------------------------
 # Handle several steps for BMI C library logic and dependencies, at top level, if functionality is turned on
 if(NGEN_WITH_BMI_C)
@@ -293,6 +324,14 @@ target_include_directories(ngen_config_header INTERFACE "${CMAKE_CURRENT_BINARY_
 
 if(NGEN_WITH_EXTERN_SLOTH)
     add_dependencies(ngen slothmodel)
+endif()
+
+if(NGEN_WITH_EXTERN_SMP)
+    add_dependencies(ngen smpbmi)
+endif()
+
+if(NGEN_WITH_EXTERN_SFT)
+    add_dependencies(ngen sftbmi)
 endif()
 
 if(NGEN_WITH_EXTERN_TOPMODEL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,6 @@ cmake_dependent_option(NGEN_WITH_EXTERN_TOPMODEL         "Build with extern-dist
 cmake_dependent_option(NGEN_WITH_EXTERN_CFE              "Build with extern-distributed CFE"              ON "NGEN_WITH_BMI_C"       OFF)
 cmake_dependent_option(NGEN_WITH_EXTERN_PET              "Build with extern-distributed PET"              ON "NGEN_WITH_BMI_C"       OFF)
 cmake_dependent_option(NGEN_WITH_EXTERN_NOAH_OWP_MODULAR "Build with extern-distributed Noah-OWP-Modular" ON "NGEN_WITH_BMI_FORTRAN" OFF)
-cmake_dependent_option(NGEN_WITH_EXTERN_PET              "Build with extern-distributed PET"              ON "NGEN_WITH_BMI_C"       OFF)
 
 # Allow enabling of all extern models dependent on NGen options given.
 option(NGEN_WITH_EXTERN_ALL OFF)


### PR DESCRIPTION
SMP and SFT have ostensibly been a part of NGIAB for a good while, but weren't being properly included in the build process.

## Additions
- *No new submodules -- we were pulling both of these, just not doing anything with them.*
- Adds SMP and SFT to build process, along with associated `NGEN_WITH_EXTERN_SMP` and `NGEN_WITH_EXTERN_SFT` options

## Changes
- If SMP or SFT are enabled, the `NGEN` option will be enabled to ensure that they build appropriately

## Testing
- At minimum, the container is building and the shared libraries for both modules are present. I haven't had the chance to test actually plugging said libraries into a model -- input from anyone with more experience would be appreciated, but barring that, I can try to do so soon.