### PR TITLE
Update dhbv2 module for hourly model

### DIFF
--- a/extern/dhbv2/README.md
+++ b/extern/dhbv2/README.md
@@ -2,15 +2,17 @@
 
 ## About
 
-This directory wraps the *dhbv2* git submodule repo, containing a clone of the repo for the MHPI δHBV2.0 module library implementing BMI. From here, the shared library file for the dhbv2 module can be built for use in NGen.
+This directory wraps the *dhbv2* git submodule repo, containing a clone of the repo for the MHPI δHBV2.0 module library (daily and hourly MTS) implementing BMI. From here, the shared library file for the dhbv2 module can be built for use in NGen.
+
+Note, dhbv2 is a collection of models currently composed of daily (*dhbv_2*) and hourly (*dhbv_2_mts*) implementations of δHBV2.0. See the [dhbv2 repository](https://github.com/mhpi/dhbv2/tree/master) for more information about these variations.
 
 #### Extra Outer Directory
 
-Currently there are two directory layers beneath the top-level *extern/* directory.  This was done so that certain things used by NGen (i.e., a *CMakeLists.txt* file for building shared library files, this readme) can be placed alongside, but not within, the submodule.
+Currently there are two directory layers beneath the top-level *extern/* directory. This was done so that certain things used by NGen (i.e., a *CMakeLists.txt* file for building shared library files, this readme) can be placed alongside, but not within, the submodule.
 
 ## Working with the Submodule
 
-Some simple explanations of several command actions are included below.  To better understand what these things are doing, consult the [Git Submodule documentation](https://git-scm.com/book/en/v2/Git-Tools-Submodules).
+Some simple explanations of several command actions are included below. To better understand what these things are doing, consult the [Git Submodule documentation](https://git-scm.com/book/en/v2/Git-Tools-Submodules).
 
 ### Getting the Latest Changes
 
@@ -55,7 +57,7 @@ Since dhbv2 is a Python submodule, dependencies located at `extern/dhbv2/dhbv2/p
 
 ## Loading Model Weights
 
-dhbv2 uses an LSTM which requires loading trained weights. Since these are too large to store with the module, they must be downloaded and installed from AWS S3 as follows. First, navigate to the submodule.
+For parameterizations, dhbv2 uses neural networks optimized weights that are loaded at runtime. Since these are too large to store within the module, they must be downloaded and installed from AWS S3 as follows. First, navigate to the submodule.
 
     cd extern/dhbv2/dhbv2
 
@@ -63,9 +65,16 @@ If AWS CLI is not installed on your system (check `aws --version`) see [AWS inst
 
 Then download model weights (and coupled normalization statistics file) from S3 like
 
-    aws s3 cp s3://mhpi-spatial/mhpi-release/models/owp/dhbv_2_hfv2.2_15y_daily.zip . --no-sign-request
-    unzip 4-dhbv_2.zip -d /temp
-    mv /temp/dhbv_2_hfv2.2_15y_daily/. /ngen_resources/data/dhbv2/models/hfv2.2_15yr
-    rm -r /temp
+    # For dhbv_2 (daily):
+    aws s3 cp s3://mhpi-spatial/mhpi-release/models/owp/dhbv_2.zip ./temp/ --no-sign-request
+    unzip ./temp/dhbv_2.zip -d ./temp
+    mv ./temp/dhbv_2/ ./ngen_resources/data/dhbv_2/model/
+    rm -r ./temp
 
-Note: Other models made available will be located in `.dhbv2/models/` with a readme providing the specific S3 URI to use above.
+    # For dhbv_2_mts (hourly):
+    aws s3 cp s3://mhpi-spatial/mhpi-release/models/owp/dhbv_2_mts.zip ./temp/ --no-sign-request
+    unzip ./temp/dhbv_2_mts.zip -d ./temp
+    mv ./temp/dhbv_2_mts/ ./ngen_resources/data/dhbv_2_mts/model/
+    rm -r ./temp
+
+Note: Other models made available will be listed in `dhbv2/ngen_resources/data/` with a readme providing the specific S3 URI to use above.


### PR DESCRIPTION
Updating the dhbv2 submodule to the latest remote version, which supports a fully-integrated, hourly-resolution differentiable HBV model, δHBV2.0 MTS (1).

(1) Yang, W., Ji, H., Lonzarich, L., Song, Y., Lawson, K., Shen, C. (2025). [In Review]

## Additions

- 

## Removals

-

## Changes

- Updated dhbv2 to latest remote version
- Updated accompanying readme (`./extern/dhbv2/README.md`) to reflect the additional model.

## Testing

1.

## Screenshots


## Notes

- dhbv2 submodule will now support both daily and hourly δHBV2.0 and δHBV2.0 MTS, respectively.

## Todos

- dhbv2 was overhauled to support the hourly model and the daily model still requires some updates for full compatibility.

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [ ] Linux
