### PR TITLE
add snow17 as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -56,3 +56,6 @@
 [submodule "extern/dhbv2/dhbv2"]
 	path = extern/dhbv2/dhbv2
 	url = https://github.com/mhpi/dhbv2
+[submodule "extern/snow17"]
+	path = extern/snow17
+	url = https://github.com/NOAA-OWP/snow17


### PR DESCRIPTION
added NOAA-OWP's snow17 as submodule in extern. SNOW17 commit: https://github.com/NOAA-OWP/snow17/tree/3a883f90049a86e05c7014910b6e34136b866d60

This doesn't change anything in cmakelists.txt, although that's what @Sheargrub does in https://github.com/CIROH-UA/ngen/pull/17. Should I have edited that as well? Or can I just save the actual shared object build for the NGIAB Dockerfile?

Closes #26 