### PR TITLE
add sac-sma as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -56,3 +56,6 @@
 [submodule "extern/dhbv2/dhbv2"]
 	path = extern/dhbv2/dhbv2
 	url = https://github.com/mhpi/dhbv2
+[submodule "extern/sac-sma"]
+	path = extern/sac-sma
+	url = https://github.com/NOAA-OWP/sac-sma


### PR DESCRIPTION
added NOAA-OWP's SAC-SMA as submodule in extern. SAC-SMA commit: https://github.com/NOAA-OWP/sac-sma/tree/975902e3d44785f3b3503f29adfb5755120f5bf5\

Closes #27 