### PR TITLE
CASAM fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -280,6 +280,8 @@ if(NGEN_WITH_BMI_C)
             GIT_UPDATE "${NGEN_EXT_DIR}/lgar-c/LGAR-C"
             IMPORTS    lasambmi
         )
+        # casam bmi function visibility is hidden without this fix
+        set_target_properties(lasambmi PROPERTIES CXX_VISIBILITY_PRESET default)
     endif()
 endif()
 

--- a/extern/lgar-c/CMakeLists.txt
+++ b/extern/lgar-c/CMakeLists.txt
@@ -41,8 +41,8 @@ target_link_libraries(lasam_unitest PRIVATE m)
 # Make sure these are compiled with this directive
 add_compile_definitions(BMI_ACTIVE)
 
-add_library(lasambmi SHARED src/bmi_lgar.cxx src/lgar.cxx ${LGAR_SRC_PREFIX}src/soil_funcs.cxx ${LGAR_SRC_PREFIX}src/linked_list.cxx ${LGAR_SRC_PREFIX}src/mem_funcs.cxx ${LGAR_SRC_PREFIX}src/conceptual_reservoir.cxx
-        ${LGAR_SRC_PREFIX}src/util_funcs.cxx ${LGAR_SRC_PREFIX}src/aet.cxx ${LGAR_SRC_PREFIX}giuh/giuh.c include/all.hxx ${LGAR_SRC_PREFIX}giuh/giuh.h)
+add_library(lasambmi SHARED ${LGAR_SRC_PREFIX}src/bmi_lgar.cxx ${LGAR_SRC_PREFIX}src/lgar.cxx ${LGAR_SRC_PREFIX}src/soil_funcs.cxx ${LGAR_SRC_PREFIX}src/linked_list.cxx ${LGAR_SRC_PREFIX}src/mem_funcs.cxx ${LGAR_SRC_PREFIX}src/conceptual_reservoir.cxx
+        ${LGAR_SRC_PREFIX}src/util_funcs.cxx ${LGAR_SRC_PREFIX}src/aet.cxx ${LGAR_SRC_PREFIX}giuh/giuh.c ${LGAR_SRC_PREFIX}include/all.hxx ${LGAR_SRC_PREFIX}giuh/giuh.h)
 
 target_compile_definitions(lasambmi PRIVATE NGEN)
 target_include_directories(lasambmi PRIVATE include)

--- a/extern/lgar-c/CMakeLists.txt
+++ b/extern/lgar-c/CMakeLists.txt
@@ -1,58 +1,48 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.10)
 
-# Uncomment this and rebuild artifacts to enable debugging
-set(CMAKE_BUILD_TYPE Debug)
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+string(ASCII 27 Esc)
+set(ColourReset "${Esc}[m")
+set(Red         "${Esc}[31m")
+# module setup options
+
+# set the project name
 project(lasambmi VERSION 1.0.0 DESCRIPTION "OWP LASAM BMI Module Shared Library")
 
-# LASAM
-set(LASAM_LIB_NAME_CMAKE lasambmi)
-set(LASAM_LIB_DESC_CMAKE "OWP LASAM BMI Module Shared Library")
+IF(CMAKE_BUILD_TYPE MATCHES Debug)
+    message("Debug build.")
+ENDIF(CMAKE_BUILD_TYPE MATCHES Debug)
+
+message(CMAKE_CXX_COMPILER " ${CMAKE_CXX_COMPILER}")
+message(CMAKE_C_COMPILER " ${CMAKE_C_COMPILER}")
+message("CMAKE_BUILD_TYPE = ${CMAKE_BUILD_TYPE}")
+
+# standalone
+add_executable(lasam_standalone ./src/bmi_main_lgar.cxx ./src/bmi_lgar.cxx ./src/lgar.cxx ./src/soil_funcs.cxx ./src/conceptual_reservoir.cxx
+            ./src/linked_list.cxx ./src/mem_funcs.cxx ./src/util_funcs.cxx ./src/aet.cxx
+            ./giuh/giuh.h ./giuh/giuh.c)
+target_link_libraries(lasam_standalone PRIVATE m)
+
+# unittest
+add_executable(lasam_unitest ./tests/main_unit_test_bmi.cxx ./src/bmi_lgar.cxx ./src/lgar.cxx ./src/soil_funcs.cxx ./src/conceptual_reservoir.cxx
+            ./src/linked_list.cxx ./src/mem_funcs.cxx ./src/util_funcs.cxx ./src/aet.cxx ./giuh/giuh.h
+            ./giuh/giuh.c)
+target_link_libraries(lasam_unitest PRIVATE m)
 
 # Make sure these are compiled with this directive
 add_compile_definitions(BMI_ACTIVE)
 
-# Based on other submodules pattern, support relative paths from ngen
-if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/LGAR-C")
-    set(LGAR_SRC_PREFIX "LGAR-C/")
-else()
-    set(LGAR_SRC_PREFIX "")
-endif()
+add_library(lasambmi SHARED src/bmi_lgar.cxx src/lgar.cxx ./src/soil_funcs.cxx ./src/linked_list.cxx ./src/mem_funcs.cxx ./src/conceptual_reservoir.cxx
+        ./src/util_funcs.cxx ./src/aet.cxx ./giuh/giuh.c include/all.hxx ./giuh/giuh.h)
 
-if(WIN32)
-  add_library(lasambmi SHARED
-    ${LGAR_SRC_PREFIX}src/bmi_lgar.cxx
-    ${LGAR_SRC_PREFIX}src/lgar.cxx
-    ${LGAR_SRC_PREFIX}src/soil_funcs.cxx
-    ${LGAR_SRC_PREFIX}src/linked_list.cxx
-    ${LGAR_SRC_PREFIX}src/mem_funcs.cxx
-    ${LGAR_SRC_PREFIX}src/util_funcs.cxx
-    ${LGAR_SRC_PREFIX}src/aet.cxx
-    ${LGAR_SRC_PREFIX}giuh/giuh.c
-    ${LGAR_SRC_PREFIX}include/all.hxx
-    ${LGAR_SRC_PREFIX}giuh/giuh.h)
-else()
-  add_library(lasambmi SHARED
-    ${LGAR_SRC_PREFIX}src/bmi_lgar.cxx
-    ${LGAR_SRC_PREFIX}src/lgar.cxx
-    ${LGAR_SRC_PREFIX}src/soil_funcs.cxx
-    ${LGAR_SRC_PREFIX}src/linked_list.cxx
-    ${LGAR_SRC_PREFIX}src/mem_funcs.cxx
-    ${LGAR_SRC_PREFIX}src/util_funcs.cxx
-    ${LGAR_SRC_PREFIX}src/aet.cxx
-    ${LGAR_SRC_PREFIX}giuh/giuh.c
-    ${LGAR_SRC_PREFIX}include/all.hxx
-    ${LGAR_SRC_PREFIX}giuh/giuh.h)
-endif()
-
-target_include_directories(lasambmi PRIVATE ${LGAR_SRC_PREFIX}include)
+target_compile_definitions(lasambmi PRIVATE NGEN)
+target_include_directories(lasambmi PRIVATE include)
 
 set_target_properties(lasambmi PROPERTIES VERSION ${PROJECT_VERSION})
 
-set_target_properties(lasambmi PROPERTIES PUBLIC_HEADER ${LGAR_SRC_PREFIX}include/bmi_lgar.hxx)
-
-# Set C++14 standard required for compilation
-set_target_properties(lasambmi PROPERTIES CXX_STANDARD 14 CXX_STANDARD_REQUIRED ON)
+set_target_properties(lasambmi PROPERTIES PUBLIC_HEADER ./include/bmi_lgar.hxx)
 
 include(GNUInstallDirs)
 
@@ -60,6 +50,6 @@ install(TARGETS lasambmi
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
-configure_file(${LGAR_SRC_PREFIX}lasambmi.pc.in lasambmi.pc @ONLY)
+configure_file(lasambmi.pc.in lasambmi.pc @ONLY)
 
 install(FILES ${CMAKE_BINARY_DIR}/lasambmi.pc DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/pkgconfig)

--- a/extern/lgar-c/CMakeLists.txt
+++ b/extern/lgar-c/CMakeLists.txt
@@ -19,23 +19,30 @@ message(CMAKE_CXX_COMPILER " ${CMAKE_CXX_COMPILER}")
 message(CMAKE_C_COMPILER " ${CMAKE_C_COMPILER}")
 message("CMAKE_BUILD_TYPE = ${CMAKE_BUILD_TYPE}")
 
+# Based on other submodules pattern, support relative paths from ngen
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/LGAR-C")
+    set(LGAR_SRC_PREFIX "LGAR-C/")
+else()
+    set(LGAR_SRC_PREFIX "")
+endif()
+
 # standalone
-add_executable(lasam_standalone ./src/bmi_main_lgar.cxx ./src/bmi_lgar.cxx ./src/lgar.cxx ./src/soil_funcs.cxx ./src/conceptual_reservoir.cxx
-            ./src/linked_list.cxx ./src/mem_funcs.cxx ./src/util_funcs.cxx ./src/aet.cxx
-            ./giuh/giuh.h ./giuh/giuh.c)
+add_executable(lasam_standalone ${LGAR_SRC_PREFIX}src/bmi_main_lgar.cxx ${LGAR_SRC_PREFIX}src/bmi_lgar.cxx ${LGAR_SRC_PREFIX}src/lgar.cxx ${LGAR_SRC_PREFIX}src/soil_funcs.cxx ${LGAR_SRC_PREFIX}src/conceptual_reservoir.cxx
+            ${LGAR_SRC_PREFIX}src/linked_list.cxx ${LGAR_SRC_PREFIX}src/mem_funcs.cxx ${LGAR_SRC_PREFIX}src/util_funcs.cxx ${LGAR_SRC_PREFIX}src/aet.cxx
+            ${LGAR_SRC_PREFIX}giuh/giuh.h ${LGAR_SRC_PREFIX}giuh/giuh.c)
 target_link_libraries(lasam_standalone PRIVATE m)
 
 # unittest
-add_executable(lasam_unitest ./tests/main_unit_test_bmi.cxx ./src/bmi_lgar.cxx ./src/lgar.cxx ./src/soil_funcs.cxx ./src/conceptual_reservoir.cxx
-            ./src/linked_list.cxx ./src/mem_funcs.cxx ./src/util_funcs.cxx ./src/aet.cxx ./giuh/giuh.h
-            ./giuh/giuh.c)
+add_executable(lasam_unitest ${LGAR_SRC_PREFIX}tests/main_unit_test_bmi.cxx ${LGAR_SRC_PREFIX}src/bmi_lgar.cxx ${LGAR_SRC_PREFIX}src/lgar.cxx ${LGAR_SRC_PREFIX}src/soil_funcs.cxx ${LGAR_SRC_PREFIX}src/conceptual_reservoir.cxx
+            ${LGAR_SRC_PREFIX}src/linked_list.cxx ${LGAR_SRC_PREFIX}src/mem_funcs.cxx ${LGAR_SRC_PREFIX}src/util_funcs.cxx ${LGAR_SRC_PREFIX}src/aet.cxx ${LGAR_SRC_PREFIX}giuh/giuh.h
+            ${LGAR_SRC_PREFIX}giuh/giuh.c)
 target_link_libraries(lasam_unitest PRIVATE m)
 
 # Make sure these are compiled with this directive
 add_compile_definitions(BMI_ACTIVE)
 
-add_library(lasambmi SHARED src/bmi_lgar.cxx src/lgar.cxx ./src/soil_funcs.cxx ./src/linked_list.cxx ./src/mem_funcs.cxx ./src/conceptual_reservoir.cxx
-        ./src/util_funcs.cxx ./src/aet.cxx ./giuh/giuh.c include/all.hxx ./giuh/giuh.h)
+add_library(lasambmi SHARED src/bmi_lgar.cxx src/lgar.cxx ${LGAR_SRC_PREFIX}src/soil_funcs.cxx ${LGAR_SRC_PREFIX}src/linked_list.cxx ${LGAR_SRC_PREFIX}src/mem_funcs.cxx ${LGAR_SRC_PREFIX}src/conceptual_reservoir.cxx
+        ${LGAR_SRC_PREFIX}src/util_funcs.cxx ${LGAR_SRC_PREFIX}src/aet.cxx ${LGAR_SRC_PREFIX}giuh/giuh.c include/all.hxx ${LGAR_SRC_PREFIX}giuh/giuh.h)
 
 target_compile_definitions(lasambmi PRIVATE NGEN)
 target_include_directories(lasambmi PRIVATE include)

--- a/extern/lgar-c/CMakeLists.txt
+++ b/extern/lgar-c/CMakeLists.txt
@@ -45,7 +45,7 @@ add_library(lasambmi SHARED ${LGAR_SRC_PREFIX}src/bmi_lgar.cxx ${LGAR_SRC_PREFIX
         ${LGAR_SRC_PREFIX}src/util_funcs.cxx ${LGAR_SRC_PREFIX}src/aet.cxx ${LGAR_SRC_PREFIX}giuh/giuh.c ${LGAR_SRC_PREFIX}include/all.hxx ${LGAR_SRC_PREFIX}giuh/giuh.h)
 
 target_compile_definitions(lasambmi PRIVATE NGEN)
-target_include_directories(lasambmi PRIVATE include)
+target_include_directories(lasambmi PRIVATE ${LGAR_SRC_PREFIX}include)
 
 set_target_properties(lasambmi PROPERTIES VERSION ${PROJECT_VERSION})
 


### PR DESCRIPTION
Closes #34. Correctly builds CASAM (formerly known as LASAM or LGAR-C) shared object to expose BMI functions properly.

## Changes

- updated CASAM submodule and its CMakeLists.txt
- updated ngen's main CMakeLists.txt to change the visibility of CASAM's symbols

## Testing

1. Tested via NGIAB against this test package I manually generated (requires CloudInfra to be updated as well to put the van Genuchton parameters in `/dmod/shared_datasets/static`
[cat-1555522.zip](https://github.com/user-attachments/files/29751543/cat-1555522.zip)


## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [X] Linux
